### PR TITLE
Combined search presets, CI/CD auto-deploy, README rewrite

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,32 @@
+name: Build & push Docker image
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ops/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest

--- a/README.md
+++ b/README.md
@@ -1,27 +1,72 @@
-# Klanavo – Demo unter [https://klanavo.zneb.to](https://klanavo.zneb.to)
+# klanavo
 
-Klanavo durchsucht Kleinanzeigen entlang einer Route und zeigt Treffer auf der Karte. Das Deployment hier ist eine Demo – für verlässlichen Betrieb bitte selbst hosten und eigene API-Keys hinterlegen.
+Klanavo sucht Kleinanzeigen entlang einer Route und zeigt die Treffer auf einer interaktiven Karte. Start- und Zielort eingeben, Suchbegriff eingeben, fertig. Die App sampelt Punkte entlang der berechneten Route und sucht in einem konfigurierbaren Radius darum herum.
+
+**Demo:** [https://klanavo.zneb.to](https://klanavo.zneb.to) — nur zu Testzwecken, bitte selbst hosten und eigene API-Keys verwenden.
 
 ## Funktionen
-- Routenplanung und Anzeige der Inserate auf einer Karte
-- Preisfilter, Gruppierung und Sortierung der Ergebnisse
-- Responsives Webfrontend
 
-## Schnellstart
-1. `cp .env.example .env` und eigenen `ORS_API_KEY` eintragen. Optional `USE_ORS_REVERSE=1` setzen.
-2. `docker-compose up --build`
+- Routenberechnung via OpenRouteService (ORS)
+- Adress-Autocomplete via ORS Geocoding + Nominatim-Fallback
+- Kleinanzeigen-Suche an Punkten entlang der Route
+- Ergebnisse auf der Karte, gruppiert nach Ort oder Kategorie
+- Preisfilter und Sortierung
+- Responsives Webfrontend, kein Build-Schritt nötig
 
-Nutzungsstatistiken werden in `data/stats.json` gespeichert. Das Verzeichnis
-ist als Volume eingebunden, sodass die Werte auch nach einem Update erhalten
-bleiben. IP-Adressen werden dabei gehasht.
+## Voraussetzungen
 
-Das Frontend steht anschließend unter [http://localhost:8401](http://localhost:8401) bereit. Wartungsmodus: `MAINTENANCE_MODE=1` plus `MAINTENANCE_KEY`.
+- Docker und Docker Compose
+- OpenRouteService API-Key: [openrouteservice.org](https://openrouteservice.org)
+
+## Quickstart
+
+```bash
+cp .env.example .env
+# ORS_API_KEY in .env eintragen
+docker compose up -d
+```
+
+Frontend läuft dann unter [http://localhost:8401](http://localhost:8401).
+
+## Umgebungsvariablen
+
+| Variable | Standard | Beschreibung |
+|---|---|---|
+| `ORS_API_KEY` | — | OpenRouteService API-Key (Pflicht) |
+| `USE_ORS_REVERSE` | `0` | ORS für Reverse-Geocoding verwenden statt Nominatim |
+| `MAINTENANCE_MODE` | `0` | App sperren, Zugang nur mit Key |
+| `MAINTENANCE_KEY` | — | Passwort für Wartungsmodus |
+
+## Updates
+
+Das Docker-Image wird bei jedem Push auf `main` automatisch gebaut und als `ghcr.io/92thms/ka-route:latest` veröffentlicht. Auf dem Server reicht dann:
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+Damit das funktioniert, muss das Paket auf GitHub unter *Packages → ka-route → Package settings* auf **Public** gestellt sein — oder man loggt sich mit `docker login ghcr.io` am Server ein.
+
+## Projektstruktur
+
+```
+api/          FastAPI-Backend (Python)
+web/          Statisches Frontend (HTML/CSS/JS)
+ops/          Dockerfile + Nginx-Konfiguration
+tests/        Pytest-Tests
+```
 
 ## Entwicklung
-Backend und Frontend liegen unter `api/` bzw. `web/`. Das Backend basiert auf FastAPI und scrapet per HTTP (ohne Browser). Die Weboberfläche ist statisch und benötigt keinen zusätzlichen Build-Schritt.
 
-## Danksagung
-Die Ermittlung der Inserate baut auf der großartigen Arbeit der [ebay-kleinanzeigen-api](https://github.com/DanielWTE/ebay-kleinanzeigen-api) auf. Vielen Dank an die Entwickler des Projekts.
+Backend und Frontend lassen sich unabhängig voneinander bearbeiten. Das Backend (`api/main.py`) startet mit Uvicorn, das Frontend ist statisch und braucht keinen Build. Tests:
+
+```bash
+pip install -r api/requirements.txt pytest
+pytest
+```
+
+Die Kleinanzeigen-Suche basiert auf [ebay-kleinanzeigen-api](https://github.com/DanielWTE/ebay-kleinanzeigen-api) von DanielWTE.
 
 ## Lizenz
+
 [MIT](LICENSE)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,10 @@
 services:
   klanavo:
-    build:
-      context: .              # <— Projekt-Root als Kontext
-      dockerfile: ops/Dockerfile
+    image: ghcr.io/92thms/ka-route:latest
     container_name: klanavo
     ports:
       - "8401:80"
     restart: unless-stopped
-    shm_size: "1g"
-    ipc: host
     environment:
       ORS_API_KEY: ${ORS_API_KEY}
       MAINTENANCE_MODE: ${MAINTENANCE_MODE:-0}

--- a/web/route.css
+++ b/web/route.css
@@ -153,6 +153,11 @@ input[type=number] { -moz-appearance: textfield; }
   flex: 1;
   min-width: 200px;
 }
+.preset-hint {
+  font-size: 11px;
+  color: var(--text-3);
+  min-height: 14px;
+}
 .chip-group {
   display: flex;
   flex-wrap: wrap;

--- a/web/route.html
+++ b/web/route.html
@@ -5,7 +5,7 @@
 <title>klanavo</title>
 <link rel="icon" type="image/png" href="favico.png">
 <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css">
-<link rel="stylesheet" href="route.css?v=5">
+<link rel="stylesheet" href="route.css?v=6">
 
 <body>
 <div class="app-header">
@@ -48,22 +48,14 @@
 
   <div class="group settings-group" id="grpSettings">
     <div class="setting-block">
-      <span class="setting-label">Suchradius pro Punkt</span>
-      <div class="chip-group" id="radiusChips">
-        <button class="chip" data-value="5">5 km</button>
-        <button class="chip" data-value="10">10 km</button>
-        <button class="chip" data-value="20">20 km</button>
-        <button class="chip" data-value="30">30 km</button>
+      <span class="setting-label">Suchtiefe</span>
+      <div class="chip-group" id="presetChips">
+        <button class="chip preset-chip" data-step="50" data-radius="10" title="Suchpunkte alle 50 km · Suchradius je 10 km">Schnell</button>
+        <button class="chip preset-chip" data-step="25" data-radius="15" title="Suchpunkte alle 25 km · Suchradius je 15 km">Standard</button>
+        <button class="chip preset-chip" data-step="10" data-radius="20" title="Suchpunkte alle 10 km · Suchradius je 20 km">Genau</button>
+        <button class="chip preset-chip" data-step="5" data-radius="30" title="Suchpunkte alle 5 km · Suchradius je 30 km">Fein</button>
       </div>
-    </div>
-    <div class="setting-block">
-      <span class="setting-label">Punktabstand entlang Route</span>
-      <div class="chip-group" id="stepChips">
-        <button class="chip" data-value="5">5 km</button>
-        <button class="chip" data-value="10">10 km</button>
-        <button class="chip" data-value="25">25 km</button>
-        <button class="chip" data-value="50">50 km</button>
-      </div>
+      <span id="presetHint" class="preset-hint"></span>
     </div>
   </div>
 
@@ -127,6 +119,6 @@
 
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <script src="config.js"></script>
-<script src="route.js?v=5"></script>
+<script src="route.js?v=6"></script>
 </body>
 </html>

--- a/web/route.js
+++ b/web/route.js
@@ -25,24 +25,27 @@ if(MAINTENANCE_MODE && MAINTENANCE_KEY){
   appEl.classList.remove("hidden");
 }
 
-let rKm = 10;
-let stepKm = 10;
+let rKm = 15;
+let stepKm = 25;
 
-function setupChips(groupId, defaultVal, onChange){
-  const group=document.getElementById(groupId);
+(function setupPresets(){
+  const group = document.getElementById('presetChips');
+  const hint  = document.getElementById('presetHint');
   if(!group) return;
-  group.querySelectorAll('.chip').forEach(chip=>{
-    const v=parseInt(chip.dataset.value,10);
-    if(v===defaultVal) chip.classList.add('active');
-    chip.addEventListener('click',()=>{
-      group.querySelectorAll('.chip').forEach(c=>c.classList.remove('active'));
-      chip.classList.add('active');
-      onChange(parseInt(chip.dataset.value,10));
-    });
+  function activate(chip){
+    group.querySelectorAll('.chip').forEach(c=>c.classList.remove('active'));
+    chip.classList.add('active');
+    stepKm = parseInt(chip.dataset.step, 10);
+    rKm    = parseInt(chip.dataset.radius, 10);
+    if(hint) hint.textContent = `${stepKm} km Abstand · ${rKm} km Radius`;
+  }
+  group.querySelectorAll('.preset-chip').forEach(chip=>{
+    if(parseInt(chip.dataset.step,10)===stepKm && parseInt(chip.dataset.radius,10)===rKm){
+      activate(chip);
+    }
+    chip.addEventListener('click', ()=> activate(chip));
   });
-}
-setupChips('radiusChips', rKm,   v=>{ rKm=v;   });
-setupChips('stepChips',   stepKm, v=>{ stepKm=v; });
+})();
 
 function escapeHtml(str){
   return String(str).replace(/[&<>"']/g, s => ({


### PR DESCRIPTION
## Summary

- Replace separate radius + step chip rows with a single "Suchtiefe" preset (Schnell / Standard / Genau / Fein); tooltip shows exact km values on hover, hint text below shows active values
- Add GitHub Actions workflow that builds and pushes `ghcr.io/92thms/ka-route:latest` on every push to main — server update is now just `docker compose pull && docker compose up -d`
- Remove `build:` section from docker-compose.yml, add pre-built image reference
- README fully rewritten with setup instructions, env var table, update workflow, project structure

## ghcr.io setup (einmalig nach merge)

Nach dem Merge triggert der Workflow beim nächsten Push auf main. Damit `docker compose pull` ohne Login funktioniert: GitHub → Packages → ka-route → Package settings → **Public** setzen.

## Test plan

- [ ] Suchtiefe-Chips wählen und Route berechnen — step/radius passen sich an
- [ ] Tooltip auf Chip zeigt korrekte km-Werte
- [ ] Hint-Text unter Chips aktualisiert sich bei Auswahl
- [ ] Nach Merge: GitHub Actions baut Image erfolgreich durch
- [ ] `docker compose pull && docker compose up -d` zieht neue Version

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTdwbxP1eRgAGUgpxa3pyE)_