### PR TITLE
Fix 0 Inserate: scraper headers, error surfacing, JS reference error

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -334,6 +334,7 @@ async def route_search(req: RouteSearchRequest, request: Request) -> dict:
 
         results: list[dict] = []
         seen: set[str] = set()
+        scrape_errors: list[str] = []
         for plz in plzs:
             try:
                 items = await _fetch_listings(
@@ -344,7 +345,8 @@ async def route_search(req: RouteSearchRequest, request: Request) -> dict:
                     max_price=req.max_price,
                     category=req.category,
                 )
-            except Exception:
+            except Exception as exc:
+                scrape_errors.append(str(exc))
                 continue
             for it in items:
                 url = it.get("url")
@@ -365,7 +367,10 @@ async def route_search(req: RouteSearchRequest, request: Request) -> dict:
         _stats["visitors"].add(_anonymise_ip(ip))
     _persist_stats()
 
-    return {"route": coords, "listings": results}
+    resp: dict = {"route": coords, "listings": results}
+    if scrape_errors:
+        resp["scrape_errors"] = scrape_errors
+    return resp
 
 
 @app.get("/stats")

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,5 +1,5 @@
 fastapi>=0.115.6
 uvicorn>=0.34.0
 python-multipart>=0.0.20
-httpx
+httpx[http2]
 beautifulsoup4

--- a/api/scraper_http.py
+++ b/api/scraper_http.py
@@ -23,12 +23,21 @@ _client_lock = asyncio.Lock()
 DEFAULT_HEADERS = {
     "User-Agent": (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
     ),
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-    "Accept-Language": "de-DE,de;q=0.9,en;q=0.8",
-    "Cache-Control": "no-cache",
-    "Pragma": "no-cache",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+    "Accept-Language": "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7",
+    "Accept-Encoding": "gzip, deflate, br, zstd",
+    "Cache-Control": "max-age=0",
+    "Upgrade-Insecure-Requests": "1",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+    "sec-ch-ua": '"Chromium";v="136", "Google Chrome";v="136", "Not.A/Brand";v="99"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"Windows"',
+    "DNT": "1",
 }
 
 
@@ -37,7 +46,7 @@ async def _get_client() -> httpx.AsyncClient:
     if _client is None:
         async with _client_lock:
             if _client is None:
-                _client = httpx.AsyncClient(headers=DEFAULT_HEADERS, timeout=30.0)
+                _client = httpx.AsyncClient(headers=DEFAULT_HEADERS, timeout=30.0, http2=True, follow_redirects=True)
     return _client
 
 

--- a/web/route.html
+++ b/web/route.html
@@ -119,6 +119,6 @@
 
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <script src="config.js"></script>
-<script src="route.js?v=9"></script>
+<script src="route.js?v=10"></script>
 </body>
 </html>

--- a/web/route.js
+++ b/web/route.js
@@ -560,7 +560,7 @@ async function parseListingDetails(html){
     if(pm) price=pm[1].toString().trim();
   }
 
-  return {title,postal,cityText,price:formatPrice(price),image,lat,lon,categories};
+  return {title,postal,price:formatPrice(price),image,lat,lon,categories};
 }
 
 const _plzLabelCache={};
@@ -810,6 +810,9 @@ async function run(){
       L.marker(zielLatLng,{icon:redIcon}).addTo(resultMarkers).bindPopup("Ziel");
     }
     const items=data.listings||[];
+    if(items.length===0 && data.scrape_errors?.length){
+      throw new Error(`Scraper-Fehler: ${data.scrape_errors[0].slice(0,120)}`);
+    }
     let added=0;
     resultItems.length=0;
     for(let i=0;i<items.length;i++){


### PR DESCRIPTION
## Was war kaputt

Kleinanzeigen blockierte den Scraper (403). Der Backend-Code hat den Fehler still geschluckt (`except Exception: continue`) → 0 Ergebnisse ohne Fehlermeldung.

Außerdem: `cityText` war aus `parseListingDetails` entfernt worden, aber noch im `return`-Statement → `ReferenceError` in strict mode bei jedem Listing-Detail-Abruf.

## Änderungen

- **scraper_http.py**: Chrome 136 User-Agent + vollständige `sec-ch-ua`/`Sec-Fetch-*` Header + HTTP/2
- **requirements.txt**: `httpx[http2]` statt nur `httpx`
- **main.py**: Scraper-Fehler werden pro PLZ gesammelt und in der API-Antwort zurückgegeben statt still ignoriert
- **route.js**: Scraper-Fehler werden im Fortschrittsbalken angezeigt statt "Fertig – 0 Inserate"
- **route.js**: `cityText` aus dem `return`-Statement von `parseListingDetails` entfernt

## Nach dem Merge

Falls noch 403 kommt: Der Fortschrittsbalken zeigt jetzt den genauen Fehlertext. Bitte Screenshot schicken damit ich weiss was Kleinanzeigen zurückgibt.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTdwbxP1eRgAGUgpxa3pyE)_