### PR TITLE
Fix missing images, categories, pins: proxy endpoint headers

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -416,16 +416,24 @@ async def proxy(u: str) -> Response:
     headers = {
         "User-Agent": (
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
         ),
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Language": "de-DE,de;q=0.9",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+        "Accept-Language": "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7",
+        "Accept-Encoding": "gzip, deflate, br",
         "Referer": "https://www.kleinanzeigen.de/",
-        "Cache-Control": "no-cache",
+        "Cache-Control": "max-age=0",
+        "Upgrade-Insecure-Requests": "1",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "same-origin",
+        "sec-ch-ua": '"Chromium";v="136", "Google Chrome";v="136", "Not.A/Brand";v="99"',
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": '"Windows"',
     }
 
     try:
-        async with httpx.AsyncClient(follow_redirects=True) as client:
+        async with httpx.AsyncClient(follow_redirects=True, http2=True) as client:
             resp = await client.get(u, headers=headers)
     except Exception as exc:  # pragma: no cover - network issues
         raise HTTPException(status_code=502, detail=str(exc)) from exc


### PR DESCRIPTION
## Ursache

Der `/proxy`-Endpoint (zuständig für Kleinanzeigen-Detailseiten und Nominatim) hatte noch die alten Chrome/124-Header und kein HTTP/2. Detailseiten-Fetches schlugen alle mit 403 fehl → keine Bilder, keine Kategorien, keine JSON-LD-Koordinaten → alles "Unbekannt", keine Pins.

Der Scraper hatte bereits Chrome 136-Header (aus dem letzten PR), aber der Proxy-Endpoint wurde vergessen.

## Änderung

`/proxy`-Endpoint: Chrome 136 + vollständige `sec-ch-ua`/`Sec-Fetch-*`-Header + HTTP/2, identisch zum Scraper-Client.

## Erwartetes Ergebnis

- Bilder laden wieder
- Kategorien werden erkannt (kein "Unbekannt" mehr)
- Pins werden gesetzt (lat/lon aus JSON-LD der Detailseite)
- Ortsnamen aus Nominatim kommen auch wieder durch

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTdwbxP1eRgAGUgpxa3pyE)_