### PR TITLE
Fix city labels overwritten by bare PLZ, add pin diagnostics

### DIFF
--- a/web/route.html
+++ b/web/route.html
@@ -119,6 +119,6 @@
 
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <script src="config.js"></script>
-<script src="route.js?v=11"></script>
+<script src="route.js?v=12"></script>
 </body>
 </html>

--- a/web/route.js
+++ b/web/route.js
@@ -652,7 +652,11 @@ async function enrichListing(it,wantDetails=true){
   if(postal){
     try{
       const g=await reversePLZ(postal);
-      label=g.display;
+      // Only replace label if reversePLZ gives a better result (has city name).
+      // Backend label like "88090 Immenstadt" is already good; g.display may be just "88090".
+      const hasCity=s=>s&&/\S+\s+\S/.test(s.trim());
+      if(hasCity(g.display) && !hasCity(label)) label=g.display;
+      else if(!label) label=g.display||postal;
       if(lat==null && g.lat!=null) lat=g.lat;
       if(lon==null && g.lon!=null) lon=g.lon;
     }catch(_){}
@@ -828,7 +832,7 @@ async function run(){
         const cluster=addListingToClusters(info.lat,info.lon);
         resultItems.push({label,cardHtml,priceVal:parsePriceVal(info.price),category:catName,clusterId:cluster.id});
       } else {
-        // Kein Geotag: trotzdem in der Liste zeigen, aber ohne Karte/Cluster
+        console.error('No coords for listing — backend sent lat='+it.lat+' lon='+it.lon+' | after enrich lat='+info.lat+' lon='+info.lon+' | url='+it.url);
         resultItems.push({label,cardHtml,priceVal:parsePriceVal(info.price),category:catName,clusterId:null});
       }
       added++;


### PR DESCRIPTION
## Summary

- **City names in results fixed**: `reversePLZ` was unconditionally overwriting the backend label (e.g. "88090 Immenstadt") with `g.display`, which is sometimes just the bare PLZ "88090" when ORS and Nominatim both fail to return a city name. Now only replaces the label if `g.display` actually contains a city name (two non-whitespace tokens).
- **Pin diagnostics added**: When a listing ends up with no coordinates after enrichment, a `console.error` is logged with the raw backend `lat`/`lon` and the post-enrich values. Open browser devtools → Console and look for "No coords for listing" lines to see what's happening with pins.

## Note on pins

The backend always sets `it.lat`/`it.lon` from the ORS route sample point, so pins should appear. If they still don't show after merging, open devtools console during a search — the error log will reveal whether `it.lat`/`it.lon` are arriving null from the API or being lost during enrichment.

https://claude.ai/code/session_01QTdwbxP1eRgAGUgpxa3pyE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTdwbxP1eRgAGUgpxa3pyE)_