### PR TITLE
Fix pins, city labels, default grouping, pin-filter clear button

### DIFF
--- a/web/route.css
+++ b/web/route.css
@@ -347,6 +347,19 @@ input[type=number] { -moz-appearance: textfield; }
   border-color: var(--accent);
   color: var(--accent);
 }
+.pin-clear {
+  align-self: flex-end;
+  padding: 6px 12px;
+  background: var(--accent-dim);
+  border: 1px solid var(--accent);
+  border-radius: var(--r-sm);
+  color: var(--accent);
+  cursor: pointer;
+  font: 600 12px/1 inherit;
+  transition: background 0.12s, color 0.12s;
+}
+.pin-clear:hover { background: var(--accent); color: #fff; }
+.pin-clear.hidden { display: none; }
 
 /* ── Grouped result boxes ───────────────────────────────────── */
 .groupbox {

--- a/web/route.html
+++ b/web/route.html
@@ -119,6 +119,6 @@
 
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <script src="config.js"></script>
-<script src="route.js?v=12"></script>
+<script src="route.js?v=13"></script>
 </body>
 </html>

--- a/web/route.html
+++ b/web/route.html
@@ -5,7 +5,7 @@
 <title>klanavo</title>
 <link rel="icon" type="image/png" href="favico.png">
 <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css">
-<link rel="stylesheet" href="route.css?v=7">
+<link rel="stylesheet" href="route.css?v=8">
 
 <body>
 <div class="app-header">
@@ -95,6 +95,7 @@
           <button id="sortPrice" data-dir="asc" title="Nach Preis sortieren"></button>
         </div>
       </div>
+      <button id="clearPinFilter" class="pin-clear hidden" title="Pin-Filter aufheben">✕ Pin-Filter</button>
     </div>
     <div id="resultGallery" class="gallery"></div>
   </div>
@@ -119,6 +120,6 @@
 
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <script src="config.js"></script>
-<script src="route.js?v=13"></script>
+<script src="route.js?v=14"></script>
 </body>
 </html>

--- a/web/route.js
+++ b/web/route.js
@@ -69,7 +69,7 @@ const resultMarkers = L.layerGroup().addTo(map);
 // Shorthands
 const $=sel=>document.querySelector(sel);
 const startGroup=$("#grpStart"), zielGroup=$("#grpZiel"), queryGroup=$("#grpQuery"), settingsGroup=$("#grpSettings"), runGroup=$("#grpRun"), resetGroup=$("#grpReset"), mapBox=$("#map-box"), resultsBox=$("#results"), resultGallery=$("#resultGallery");
-const filterPriceMin=$("#filterPriceMin"), filterPriceMax=$("#filterPriceMax"), sortPriceBtn=$("#sortPrice"), groupBtn=$("#toggleGrouping"), analyticsBox=$("#analytics");
+const filterPriceMin=$("#filterPriceMin"), filterPriceMax=$("#filterPriceMax"), sortPriceBtn=$("#sortPrice"), groupBtn=$("#toggleGrouping"), clearPinBtn=$("#clearPinFilter"), analyticsBox=$("#analytics");
 const queryWarn=$("#queryWarn");
 $("#query").addEventListener('input',()=>queryWarn.classList.add('hidden'));
 
@@ -128,6 +128,7 @@ function clearResults(){
   r.querySelectorAll('.groupbox').forEach(el=>el.remove());
   resultGallery.innerHTML='';
   resultMarkers.clearLayers();markerClusters.length=0;activeCluster=null;
+  if(clearPinBtn) clearPinBtn.classList.add('hidden');
   groups.clear();
   lastRenderedIdx=0;
 }
@@ -149,7 +150,7 @@ let sortField='price';
 let sortDir=1; // 1=asc, -1=desc
 
 const GROUP_NONE=0, GROUP_LOCATION=1, GROUP_CATEGORY=2;
-let groupMode=GROUP_CATEGORY;
+let groupMode=GROUP_LOCATION;
 
 const ICONS={
   location:`<svg class="icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"></path><circle cx="12" cy="10" r="3"></circle></svg>`,
@@ -160,8 +161,8 @@ const ICONS={
   arrowDown:`<svg class="icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14"></path><path d="m19 12-7 7-7-7"></path></svg>`
 };
 
-groupBtn.innerHTML=ICONS.ungroup;
-groupBtn.title='Gruppierung aufheben';
+groupBtn.innerHTML=ICONS.category;
+groupBtn.title='Nach Kategorie gruppieren';
 
 function parsePriceVal(str){
   const cleaned=String(str).replace(/VB/i,'').replace(/€/g,'').replace(/\u00a0/g,'').trim();
@@ -296,9 +297,9 @@ $("#btnReset").addEventListener('click', () => {
   resultsBox.classList.add("hidden");
   if(routeLayer){ map.removeLayer(routeLayer); routeLayer=null; }
   clearResults();
-  groupMode=GROUP_CATEGORY;
-  groupBtn.innerHTML=ICONS.ungroup;
-  groupBtn.title='Gruppierung aufheben';
+  groupMode=GROUP_LOCATION;
+  groupBtn.innerHTML=ICONS.category;
+  groupBtn.title='Nach Kategorie gruppieren';
   sortField='price';
   sortDir=1;
   updateSortButtons();
@@ -397,8 +398,13 @@ function highlightCluster(id){
     const cluster = markerClusters[activeCluster];
     cluster.marker.setIcon(orangeIcon);
     document.querySelectorAll(`[data-cluster="${activeCluster}"]`).forEach(el=>el.classList.add('highlight'));
+    clearPinBtn.classList.remove('hidden');
+  }else{
+    clearPinBtn.classList.add('hidden');
   }
 }
+
+clearPinBtn.addEventListener('click', () => highlightCluster(null));
 
 map.on('click', () => highlightCluster(null));
 
@@ -641,13 +647,13 @@ async function geocodeTextOnce(text){
 }
 
 async function enrichListing(it,wantDetails=true){
-  // Backend always provides route-sample-point coords; keep them as the safety net.
+  // Backend gives route-sample-point coords as last-resort fallback.
   const baseLat = isDeCoord(it.lat, it.lon) ? it.lat : null;
   const baseLon = isDeCoord(it.lat, it.lon) ? it.lon : null;
   const baseLabel = it.label || null;
   const basePostal = isPlz(it.plz) ? it.plz : null;
 
-  let lat = baseLat, lon = baseLon;
+  let lat=null, lon=null;
   let postal = basePostal;
   let label = baseLabel;
   let price = formatPrice(it.price||"");
@@ -661,25 +667,26 @@ async function enrichListing(it,wantDetails=true){
       if(det.price) price=det.price;
       if(det.image) image=det.image;
       if(isPlz(det.postal)) postal=det.postal;
-      // Override route-point coords only when listing has real (Germany-valid) coords.
+      // Best source: exact coordinates from the listing's own detail page
       if(isDeCoord(det.lat, det.lon)){ lat=det.lat; lon=det.lon; }
       categories=det.categories;
       if(det.categories&&det.categories.length){ category=det.categories[det.categories.length-1]; }
     }catch(_){}
   }
 
-  // Resolve city name from postal code; only upgrade label when we get a real city.
+  // Geocode the listing's own PLZ — gives city name and PLZ-centroid coords.
+  // Prefer these over route sample points because they reflect the actual listing location.
   if(postal){
     try{
       const g=await reversePLZ(postal);
       const hasCity=s=>typeof s==='string' && /\S+\s+\S/.test(s.trim());
       if(hasCity(g.display)) label=g.display;
       else if(!hasCity(label)) label=g.display||postal;
-      if(lat==null && isDeCoord(g.lat,g.lon)){ lat=g.lat; lon=g.lon; }
+      if(!isDeCoord(lat,lon) && isDeCoord(g.lat,g.lon)){ lat=g.lat; lon=g.lon; }
     }catch(_){}
   }
 
-  // Final safety net: if anything blew away coords, fall back to backend's route point.
+  // Last resort: route sample point so the listing at least appears on the map.
   if(!isDeCoord(lat,lon)){ lat=baseLat; lon=baseLon; }
   if(!label) label=baseLabel||postal||"?";
 

--- a/web/route.js
+++ b/web/route.js
@@ -476,6 +476,14 @@ function formatPrice(p){
 // -------- Parsing --------
 function cityFromAddr(a){return a?.city||a?.town||a?.village||a?.municipality||a?.county||'';}
 function safeParse(json){try{return JSON.parse(json);}catch(_){return null;}}
+// Validate a coordinate pair falls inside Germany (rough bbox).
+// Filters out NaN, 0, ocean placeholders, and other junk from regex fallbacks.
+function isDeCoord(la, lo){
+  return typeof la === 'number' && typeof lo === 'number'
+      && isFinite(la) && isFinite(lo)
+      && la > 47 && la < 56 && lo > 5 && lo < 16;
+}
+function isPlz(p){ return typeof p === 'string' && /^\d{5}$/.test(p); }
 async function parseListingDetails(html){
   const doc=new DOMParser().parseFromString(html,'text/html');
   const title=doc.querySelector('meta[property="og:title"]')?.content||doc.title||null;
@@ -491,14 +499,15 @@ async function parseListingDetails(html){
     try{
       const obj=JSON.parse(s.textContent);
       const addr=obj.address||obj.itemOffered?.address||obj.offers?.seller?.address;
-      if(addr){
-        postal=postal||addr.postalCode||addr.postcode||addr.zip;
+      if(addr && !postal){
+        const cand=String(addr.postalCode||addr.postcode||addr.zip||'');
+        if(isPlz(cand)) postal=cand;
       }
       if(!image && obj.image){ image=Array.isArray(obj.image)?obj.image[0]:(typeof obj.image==='string'?obj.image:null); }
       const g=obj.geo||obj.location||obj.address?.geo;
       if(g){
         const la=parseFloat(g.latitude||g.lat); const lo=parseFloat(g.longitude||g.lon||g.lng);
-        if(!Number.isNaN(la)&&!Number.isNaN(lo)){ lat=lat??la; lon=lon??lo; }
+        if(isDeCoord(la,lo)){ lat=lat??la; lon=lon??lo; }
       }
     }catch(_){}
   });
@@ -513,11 +522,14 @@ async function parseListingDetails(html){
           const st=safeParse(t.slice(start,end+1));
           const a=st?.ad?.adAddress||st?.adInfo?.address||st?.adData?.address||null;
           if(a){
-            postal=postal||a.postalCode||a.postcode||a.zipCode;
+            if(!postal){
+              const cand=String(a.postalCode||a.postcode||a.zipCode||'');
+              if(isPlz(cand)) postal=cand;
+            }
             const g=a.geo||a.coordinates||a.location;
             if(g){
               const la=parseFloat(g.lat||g.latitude); const lo=parseFloat(g.lon||g.lng||g.longitude);
-              if(!Number.isNaN(la)&&!Number.isNaN(lo)){ lat=lat??la; lon=lon??lo; }
+              if(isDeCoord(la,lo)){ lat=lat??la; lon=lon??lo; }
             }
           }
         }
@@ -527,9 +539,10 @@ async function parseListingDetails(html){
 
   // 3) Specific meta tags for postal code (reliable, not from description text)
   if(!postal){
-    postal = doc.querySelector('meta[property="og:postal-code"]')?.content
-          || doc.querySelector('meta[name="postal-code"]')?.content
-          || null;
+    const cand = doc.querySelector('meta[property="og:postal-code"]')?.content
+              || doc.querySelector('meta[name="postal-code"]')?.content
+              || '';
+    if(isPlz(cand)) postal = cand;
   }
 
   // 4) Known Kleinanzeigen location element — extract leading 5-digit PLZ only
@@ -541,11 +554,14 @@ async function parseListingDetails(html){
     }
   }
 
-  // 5) lat/lon raw regex fallback (for listings that embed coordinates but not via JSON-LD)
+  // 5) lat/lon raw regex fallback — only if it looks like a real German coordinate
   if(lat===null||lon===null){
     const lm=html.match(/"(?:latitude|lat)"\s*:\s*([0-9.+-]+)/i);
     const lom=html.match(/"(?:longitude|lon|lng)"\s*:\s*([0-9.+-]+)/i);
-    if(lm&&lom){ lat=parseFloat(lm[1]); lon=parseFloat(lom[1]); }
+    if(lm&&lom){
+      const la=parseFloat(lm[1]), lo=parseFloat(lom[1]);
+      if(isDeCoord(la,lo)){ lat=la; lon=lo; }
+    }
   }
 
   // Preis
@@ -625,12 +641,16 @@ async function geocodeTextOnce(text){
 }
 
 async function enrichListing(it,wantDetails=true){
-  // Route sample-point coords are ALWAYS available from the backend — use them as default
-  let lat = (it.lat != null) ? it.lat : null;
-  let lon = (it.lon != null) ? it.lon : null;
-  let price=formatPrice(it.price||"");
-  let postal=it.plz||null;
-  let label=it.label||null;
+  // Backend always provides route-sample-point coords; keep them as the safety net.
+  const baseLat = isDeCoord(it.lat, it.lon) ? it.lat : null;
+  const baseLon = isDeCoord(it.lat, it.lon) ? it.lon : null;
+  const baseLabel = it.label || null;
+  const basePostal = isPlz(it.plz) ? it.plz : null;
+
+  let lat = baseLat, lon = baseLon;
+  let postal = basePostal;
+  let label = baseLabel;
+  let price = formatPrice(it.price||"");
   let image=null, categories=null, category=null;
 
   if(wantDetails){
@@ -640,29 +660,28 @@ async function enrichListing(it,wantDetails=true){
       if(det.title) it.title=det.title;
       if(det.price) price=det.price;
       if(det.image) image=det.image;
-      if(det.postal) postal=det.postal;
-      // Exact JSON-LD coords override route sample point when available
-      if(det.lat!=null && det.lon!=null){ lat=det.lat; lon=det.lon; }
+      if(isPlz(det.postal)) postal=det.postal;
+      // Override route-point coords only when listing has real (Germany-valid) coords.
+      if(isDeCoord(det.lat, det.lon)){ lat=det.lat; lon=det.lon; }
       categories=det.categories;
       if(det.categories&&det.categories.length){ category=det.categories[det.categories.length-1]; }
     }catch(_){}
   }
 
-  // Resolve city name from postal code; update coords only if we still have none
+  // Resolve city name from postal code; only upgrade label when we get a real city.
   if(postal){
     try{
       const g=await reversePLZ(postal);
-      // Only replace label if reversePLZ gives a better result (has city name).
-      // Backend label like "88090 Immenstadt" is already good; g.display may be just "88090".
-      const hasCity=s=>s&&/\S+\s+\S/.test(s.trim());
-      if(hasCity(g.display) && !hasCity(label)) label=g.display;
-      else if(!label) label=g.display||postal;
-      if(lat==null && g.lat!=null) lat=g.lat;
-      if(lon==null && g.lon!=null) lon=g.lon;
+      const hasCity=s=>typeof s==='string' && /\S+\s+\S/.test(s.trim());
+      if(hasCity(g.display)) label=g.display;
+      else if(!hasCity(label)) label=g.display||postal;
+      if(lat==null && isDeCoord(g.lat,g.lon)){ lat=g.lat; lon=g.lon; }
     }catch(_){}
   }
 
-  if(!label) label=postal||"?";
+  // Final safety net: if anything blew away coords, fall back to backend's route point.
+  if(!isDeCoord(lat,lon)){ lat=baseLat; lon=baseLon; }
+  if(!label) label=baseLabel||postal||"?";
 
   return {lat,lon,label,price,image,postal,categories,category};
 }


### PR DESCRIPTION
## Summary

- **Pins zeigen jetzt echte Listing-Koordinaten**: PLZ des Inserats wird per reversePLZ geocoded und als Pinposition verwendet — nicht mehr der Routensuchpunkt. Fallback auf Routenpunkt nur wenn alles andere scheitert.
- **Germany bbox-Validierung**: Alle extrahierten Koordinaten (JSON-LD, __INITIAL_STATE__, Regex-Fallback) werden auf Deutschland-Bounding-Box geprüft. NaN, 0, und Ozean-Koordinaten werden abgelehnt.
- **PLZ-Validierung**: Postleitzahlen müssen exakt 5 Ziffern haben bevor sie weiterverwendet werden.
- **Stadtname nicht mehr überschrieben**: reversePLZ ersetzt das Label nur noch wenn es wirklich einen Stadtnamen enthält (PLZ + Stadt), nicht bei bloßer PLZ.
- **Standardansicht "Nach Ort gruppiert"**: Ergebnisse sind direkt nach Ort gruppiert, nicht nach Kategorie.
- **"✕ Pin-Filter" Button**: Erscheint wenn ein Kartenpin angeklickt wird, ermöglicht das Aufheben des Cluster-Filters ohne auf die Karte zu klicken.

## CSS/JS Versionen

- `route.js?v=14`, `route.css?v=8`

https://claude.ai/code/session_01QTdwbxP1eRgAGUgpxa3pyE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTdwbxP1eRgAGUgpxa3pyE)_